### PR TITLE
added travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,156 @@
+# https://docs.haskellstack.org/en/stable/travis_ci/
+
+# Use new container infrastructure to enable caching
+sudo: true
+dist: trusty
+# services:
+#   - docker
+
+# Do not choose a language; we provide our own build tools.
+language: generic
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.ghc
+  - $HOME/.cabal
+  - $HOME/.stack
+
+matrix:
+  include:
+  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 7.10.3"
+    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.0.1 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.0.1"
+    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.0.2"
+    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+
+  # Build with the newest GHC and cabal-install. This is an accepted failure,
+  # see below.
+  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC HEAD"
+    addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+
+  # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
+  # variable, such as using --stack-yaml to point to a different file.
+  - env: BUILD=stack ARGS=""
+    compiler: ": #stack default"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--stack-yaml stack-7.yaml"
+    compiler: ": #stack 8.0.1"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-8"
+    compiler: ": #stack 8.0.8"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  # Nightly builds are allowed to fail
+  - env: BUILD=stack ARGS="--resolver nightly"
+    compiler: ": #stack nightly"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  # Build on macOS in addition to Linux
+  - env: BUILD=stack ARGS=""
+    compiler: ": #stack default osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--stack-yaml stack-7.yaml"
+    compiler: ": #stack 8.0.1 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-8"
+    compiler: ": #stack 8.0.2 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver nightly"
+    compiler: ": #stack nightly osx"
+    os: osx
+
+  allow_failures:
+  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
+  - env: BUILD=stack ARGS="--resolver nightly"
+
+before_install:
+# Using compiler above sets CC to an invalid value, so unset it
+- unset CC
+
+# We want to always allow newer versions of packages when building on GHC HEAD
+- CABALARGS=""
+- if [ "x$GHCVER" = "xhead" ]; then CABALARGS=--allow-newer; fi
+
+# Download and unpack the stack executable
+- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
+- mkdir -p ~/.local/bin
+- |
+  if [ `uname` = "Darwin" ]
+  then
+    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+  else
+    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  fi
+
+  # Use the more reliable S3 mirror of Hackage
+  mkdir -p $HOME/.cabal
+  echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
+  echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
+
+  if [ "$CABALVER" != "1.16" ]
+  then
+    echo 'jobs: $ncpus' >> $HOME/.cabal/config
+  fi
+
+install:
+- echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+- if [ -f configure.ac ]; then autoreconf -i; fi
+- |
+  set -ex
+  case "$BUILD" in
+    stack)
+      stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+      ;;
+    cabal)
+      cabal --version
+      travis_retry cabal update
+
+      # Get the list of packages from the stack.yaml file
+      PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
+
+      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      cabal install c2hs
+      ;;
+  esac
+  set +ex
+
+script:
+- |
+  set -ex
+  case "$BUILD" in
+    stack)
+      stack --no-terminal $ARGS test --bench --no-run-benchmarks # --haddock --no-haddock-deps
+      ;;
+    cabal)
+      cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+
+      ORIGDIR=$(pwd)
+      for dir in $PACKAGES
+      do
+        cd $dir
+        cabal check || [ "$CABALVER" == "1.16" ]
+        cabal sdist
+        PKGVER=$(cabal info . | awk '{print $2;exit}')
+        SRC_TGZ=$PKGVER.tar.gz
+        cd dist
+        tar zxfv "$SRC_TGZ"
+        cd "$PKGVER"
+        cabal configure --enable-tests
+        cabal build
+        cd $ORIGDIR
+      done
+      ;;
+  esac
+  set +ex

--- a/datadog.cabal
+++ b/datadog.cabal
@@ -3,8 +3,8 @@
 
 name:                datadog
 version:             0.2.0.0
-synopsis:            Datadog client for Haskell. Supports both the HTTP API and StatsD.
--- description:
+synopsis:            Datadog client for Haskell.
+description:         Datadog client for Haskell. Supports both the HTTP API and StatsD.
 homepage:            https://github.com/iand675/datadog
 license:             MIT
 license-file:        LICENSE
@@ -15,6 +15,9 @@ category:            Network
 build-type:          Simple
 -- extra-source-files:
 cabal-version:       >=1.10
+source-repository head
+  type:     git
+  location: git://github.com/iand675/datadog.git
 
 library
   exposed-modules:     Network.Datadog,
@@ -23,7 +26,8 @@ library
                        Network.Datadog.Event,
                        Network.Datadog.Host,
                        Network.Datadog.Monitor,
-                       Network.Datadog.Types
+                       Network.Datadog.Types,
+                       Network.Datadog.Metrics,
                        Network.Datadog.Internal,
                        Network.StatsD.Datadog
                        -- Datadog.Metrics,
@@ -31,23 +35,23 @@ library
                        -- Datadog.Wai
   other-extensions:    OverloadedStrings, GeneralizedNewtypeDeriving, TemplateHaskell, FunctionalDependencies, MultiParamTypeClasses, FlexibleInstances
   build-depends:       base >=4.7 && <5,
-                       aeson >=0.8 && <0.12,
-                       http-client >=0.4 && <0.5,
-                       http-client-tls >=0.2 && <0.3,
-                       http-types >=0.8 && <=0.10,
+                       aeson,
+                       http-client,
+                       http-client-tls,
+                       http-types,
                        lens,
                        bytestring,
                        time,
                        text,
                        old-locale,
-                       buffer-builder >=0.2 && <0.3,
+                       buffer-builder,
                        auto-update,
                        network,
-                       monad-control ==1.*,
+                       monad-control,
                        lifted-base,
                        transformers-base,
-                       unordered-containers >=0.2 && <0.3,
-                       vector >=0.10 && <0.12,
+                       unordered-containers,
+                       vector,
                        dlist
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -62,11 +66,11 @@ test-suite datadog-api-test
                        Test.Network.Datadog.Host,
                        Test.Network.Datadog.Monitor,
                        Test.Network.Datadog.StatsD
-  build-depends:       base >=4.8 && <5,
-                       Cabal >=1.9.2,
+  build-depends:       base,
+                       Cabal,
                        datadog,
                        network,
-                       time >=1.5 && <1.7,
+                       time,
                        lens
   hs-source-dirs:      test
   default-language:    Haskell2010

--- a/stack-7.yaml
+++ b/stack-7.yaml
@@ -1,10 +1,11 @@
-resolver: lts-8.3
+resolver: lts-7.19
 
 packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+  - buffer-builder-0.2.4.4
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
## Changes

- Build with GHC 7.10.3, 8.0.1 and 8.0.2 with Cabal on Linux
- Build with GHC 8.0.1 and 8.0.2 with Stack on OSX
- Build with GHC 8.0.1 and 8.0.2 with Stack on Linux
- Running integration tests agains a free-tier datadog in TravisCI